### PR TITLE
Alibaba Cloud for ImageNet resnet26d inference on ecs.gn6i-c8g1.2xlarge

### DIFF
--- a/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
+++ b/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
@@ -1,0 +1,18 @@
+{
+    "version": "v2.0",
+    "author": "Perseus AI Cloud Acceleration team in Alibaba Cloud",
+    "authorEmail": "niqi.lnq@alibaba-inc.com, youliang.yl@alibaba-inc.com",
+    "framework": "Pytorch+TensorRT",
+    "codeURL": "https://github.com/ali-perseus/DAWNBench_Inference",
+    "commitHash": "bc904f374c4e6335e964ffeb9a96e5a335471f3b",
+    "model": "ResNet26d",
+    "hardware": "Alibaba Cloud [ecs.gn6i-c8g1.2xlarge]",
+    "latency": 0.637316,
+    #"cost": 1.54e-06,
+    "top5Accuracy": 93.028,
+    "timestamp": "2019-10-12",
+    "misc": {
+        "TensorRT": "TensorRT 6.0.1.5 for CentOS/RedHat 7 (https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/6.0/GA_6.0.1.5/tars/TensorRT-6.0.1.5.CentOS-7.6.x86_64-gnu.cuda-10.0.cudnn7.6.tar.gz",
+        "CUDA version": "10.0.130",
+    }
+}

--- a/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
+++ b/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
@@ -13,6 +13,8 @@
     "timestamp": "2019-10-17",
     "misc": {
         "TensorRT": "TensorRT 6.0.1.5 for CentOS/RedHat 7 (https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/6.0/GA_6.0.1.5/tars/TensorRT-6.0.1.5.CentOS-7.6.x86_64-gnu.cuda-10.0.cudnn7.6.tar.gz",
+        "Pytorch" : "Pytorch 1.2.0 with gpu support, installed by pip",
+        "torchvision" : "torchvision 0.4.0, installed by pip",
         "CUDA version": "10.0.130"
     }
 }

--- a/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
+++ b/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
@@ -1,5 +1,5 @@
 {
-    "version": "v2.0",
+    "version": "v1.0",
     "author": "Perseus AI Cloud Acceleration team in Alibaba Cloud",
     "authorEmail": "niqi.lnq@alibaba-inc.com, youliang.yl@alibaba-inc.com",
     "framework": "Pytorch+TensorRT",

--- a/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
+++ b/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
@@ -13,6 +13,6 @@
     "timestamp": "2019-10-17",
     "misc": {
         "TensorRT": "TensorRT 6.0.1.5 for CentOS/RedHat 7 (https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/6.0/GA_6.0.1.5/tars/TensorRT-6.0.1.5.CentOS-7.6.x86_64-gnu.cuda-10.0.cudnn7.6.tar.gz",
-        "CUDA version": "10.0.130",
+        "CUDA version": "10.0.130"
     }
 }

--- a/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
+++ b/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
@@ -8,9 +8,9 @@
     "model": "ResNet26d",
     "hardware": "Alibaba Cloud [ecs.gn6i-c8g1.2xlarge]",
     "latency": 0.637316,
-    #"cost": 1.54e-06,
+    "cost": 4.9e-07,
     "top5Accuracy": 93.028,
-    "timestamp": "2019-10-12",
+    "timestamp": "2019-10-17",
     "misc": {
         "TensorRT": "TensorRT 6.0.1.5 for CentOS/RedHat 7 (https://developer.nvidia.com/compute/machine-learning/tensorrt/secure/6.0/GA_6.0.1.5/tars/TensorRT-6.0.1.5.CentOS-7.6.x86_64-gnu.cuda-10.0.cudnn7.6.tar.gz",
         "CUDA version": "10.0.130",

--- a/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
+++ b/ImageNet/inference/AlibabaCloud_resnet26d_1t4_ecs_pytorch_tensorRT.json
@@ -8,7 +8,7 @@
     "model": "ResNet26d",
     "hardware": "Alibaba Cloud [ecs.gn6i-c8g1.2xlarge]",
     "latency": 0.637316,
-    "cost": 4.9e-07,
+    "cost": 3.1228484e-07,
     "top5Accuracy": 93.028,
     "timestamp": "2019-10-17",
     "misc": {


### PR DESCRIPTION
Hello~ we updated the model and framework, and we got the new records of inference time and cost.

according to the [alibabacloud website](https://cn.aliyun.com/price/product?spm=5176.8789780.1092586.1.2d0257a8rKsPw1#/ecs/detail) ,the ecs.gn6i-c8g1.2xlarge is 12.6 RMB per hour.
the US dollar/RMB exchange rate is 0.14, so the cost is 12.6\*0.14/(1000*3600)*0.637316=3.1228484e-07