### PR TITLE
ResNet26 || ImageNet Inference || Alibaba Cloud PAI

### DIFF
--- a/ImageNet/inference/AlibabaCloud_resnet26_1t4_ecs_tensorflow.json
+++ b/ImageNet/inference/AlibabaCloud_resnet26_1t4_ecs_tensorflow.json
@@ -1,0 +1,19 @@
+{
+    "version": "v1.0",
+    "author": "PAI: Platform of A.I. in Alibaba Cloud",
+    "authorEmail": "yiwu.yyw@alibaba-inc.com, muzhuo.yj@alibaba-inc.com",
+    "framework": "TensorFlow + TensorRT",
+    "codeURL": "https://github.com/AliCloud-PAI/dawnbench_infer",
+    "commitHash": "60f63128d2f6a9e7b3aa26d24b47eabe5318afff",
+    "model": "ResNet26",
+    "hardware": "Alibaba Cloud [ecs.gn6i-c8g1.2xlarge]",
+    "latency": 0.4688,
+    "top5Accuracy": 93.094,
+    "timestamp": "2020-01-15",
+    "misc": {
+        "GPU": "Tesla T4",
+        "CUDA version": "10.1.243",
+        "TensorRT": "TensorRT 6.0.1.4",
+        "TensorFlow" : "TensorFlow 1.13.1"
+    }
+}


### PR DESCRIPTION
Model that achieves top-5 accuracy=93.094 on ImageNet2012-1K validation-set in latency=0.4688 milliseconds one-at-a-time. The hardware is Alibaba Cloud [ecs.gn6i-c8g1.2xlarge], containing Tesla T4.